### PR TITLE
Generated index entries against all centos dockerfiles.

### DIFF
--- a/genindexentries.sh
+++ b/genindexentries.sh
@@ -1,0 +1,167 @@
+#!/bin/bash
+
+#################################################################################################
+#	Script generates default entries into cccp-index/index.yml for the CentOs-Dockerfiles.	#
+#												#
+#	Author : Mohammed Zeeshan Ahmed (mohammed.zee1000@gmail.com)				#
+#################################################################################################
+
+# Globals : 
+
+centosdfpath=$1;
+git_url=$2;
+git_branch=$3;
+notify_email=$4;
+
+function err(){
+	mode=$1;
+	exitc=1;
+	errmsg="";
+
+	case $mode in
+		INDEX_INCORRECT)
+			errmsg="The path specified as the index file is not a file or does not exist.";
+			exitc=2;
+		;;
+		INVAL_DFPATH)
+			errmsg="The location specified for centos dockerfiles path is invalid.";
+			exitc=3;
+		;;	
+	esac	
+
+	echo -e "ERROR : $errmsg";
+	exit $exitc;
+}
+
+function indexentry(){
+	# Usage: indexentry mode id appid jobid gitpath
+	mode=$1;
+	theid=$2;
+	app_id=$3;
+	job_id=$4;
+	git_path=$5;
+	echo "$git_path"; #TEST
+
+	indexpath="./index.yml"; # The path of the index.yml file. Please set this before running this script.
+	tmpfile="/tmp/$RANDOM";
+
+	case $mode in
+		CHK_INDEXPATH)   # Mode checks if indexpath value points to a file.
+			if [ -f $indexpath ]; then
+				# If index path exists then its fine.
+				return;		
+							
+			fi
+			# Ask user to set the value.
+			err INDEX_INCORRECT;
+		;;
+		GEN_ENTRY)
+			#entry="- id\t\t: $theid\n";
+			entry="app-id\t: $app_id\n";
+			entry+="job-id\t: $job_id\n";
+			entry+="git-url\t: $git_url\n";
+			entry+="git-path\t: $git_path\n";
+			entry+="git-branch\t: $git_branch\n";
+			entry+="notify-email: $notify_email\n";
+			echo -e $entry >> $tmpfile;
+			sed -e 's/^/  /' -i $tmpfile;
+			content=$(cat $tmpfile);
+			echo -en "- id\t\t: $theid\n$content" > $tmpfile;
+			sed -e 's/^/  /' -i $tmpfile;
+			#cat $tmpfile; #TEST;
+			cat $tmpfile >> $indexpath;
+			echo >> $indexpath;
+		;;
+	esac
+	
+}
+
+function genindexentry(){
+
+        mode=$1;
+        project=$2;
+
+
+        case $mode in
+                OSV)
+			echo "** generating indx entry for $project $osversion...";
+                        osversion=$3;
+                        t="?"; # Temp variable, used below to get first character from osversion
+                        JOBID="${osversion%"${osversion#${t}}"}${osversion: -1}-$project" # JOBID = FirstChar(osversion)LastChar(osversion)-PROJECTNAME
+			git_path="$project/$osversion/";
+
+
+                ;;
+                DIRECT)
+			echo "** generating indx entry for $project No OS Version associated ...";
+                        JOBID="centos-dockerfile-$project";
+			git_path="$project/"
+                ;;
+        esac
+	#echo "$git_path"; #TEST
+	indexentry GEN_ENTRY "default" "centos" $PROJECT $JOBID "$git_path";
+}
+
+function usage(){
+	echo "USAGE $0 <CENTOSDOCKERFILEPATH> <GITURL> <GITBRANCH> <NOTIFYEMAIL>";
+	exit 5000;
+}
+
+# MAIN BEGINS
+
+
+# Check if parameters were passed.
+if [ $# -lt 4  ]; then
+	usage;
+fi
+
+proceed="z";
+while true; do
+        echo;
+        echo "Please ensure that the indexpath value has been set in the script";
+        printf "Proceed with generation (y/n) : ";
+        read proceed;
+        #echo $proceed; #TEST
+        echo
+        if [ "$proceed" = "y" ]; then
+                break;
+        elif [ "$proceed" = "n" ]; then
+                exit 0;
+        fi
+done
+
+indexentry CHK_INDEXPATH;
+
+# Check if path is a valid directory
+if [ ! -d $centosdfpath ]; then
+
+	err INVAL_DFPATH; # Inform user of invalid path
+
+fi
+
+# Check every project directory in the Centos-Dockerfiles
+for project in `ls $centosdfpath`; do
+         #echo $project; # TEST
+        if [ -d $centosdfpath/$project  ]; then
+
+                echo "Found project : $project, getting in..."
+                ls $centosdfpath/$project | grep centos &> /dev/null; # Check if centosX directories are present in the project dir
+
+                # if there is a match process os versions
+                if [ $? -eq 0 ]; then
+
+                        echo "* Project contains centosX where X is a version, switching to osversion mode...";
+
+                        for osversion in `ls $centosdfpath/$project`; do
+
+                                genindexentry OSV $project $osversion;
+
+                        done
+                else
+                        echo "* Project does not contain centosX directories, switching to direct mode...";
+                        genindexentry DIRECT $project;
+                fi
+        fi
+        echo;
+done
+

--- a/index.yml
+++ b/index.yml
@@ -63,3 +63,381 @@ Projects:
     git-path: /
     git-branch: master
     notify-email: cgoern@gmail.com
+
+#CentOS Dockerfiles Testrun
+  - id		: default
+    app-id	: centos
+    job-id	: c6-bind
+    git-url	: https://github.com/mohammedzee1000/CentOS-Dockerfiles
+    git-path	: bind/centos6/
+    git-branch	: cccpyaml-test
+    notify-email: mohammed.zee1000@gmail.com
+    
+  - id		: default
+    app-id	: centos
+    job-id	: c7-bind
+    git-url	: https://github.com/mohammedzee1000/CentOS-Dockerfiles
+    git-path	: bind/centos7/
+    git-branch	: cccpyaml-test
+    notify-email: mohammed.zee1000@gmail.com
+    
+  - id		: default
+    app-id	: centos
+    job-id	: c6-couchdb
+    git-url	: https://github.com/mohammedzee1000/CentOS-Dockerfiles
+    git-path	: couchdb/centos6/
+    git-branch	: cccpyaml-test
+    notify-email: mohammed.zee1000@gmail.com
+    
+  - id		: default
+    app-id	: centos
+    job-id	: c7-couchdb
+    git-url	: https://github.com/mohammedzee1000/CentOS-Dockerfiles
+    git-path	: couchdb/centos7/
+    git-branch	: cccpyaml-test
+    notify-email: mohammed.zee1000@gmail.com
+    
+  - id		: default
+    app-id	: centos
+    job-id	: c6-Django
+    git-url	: https://github.com/mohammedzee1000/CentOS-Dockerfiles
+    git-path	: Django/centos6/
+    git-branch	: cccpyaml-test
+    notify-email: mohammed.zee1000@gmail.com
+    
+  - id		: default
+    app-id	: centos
+    job-id	: c7-Django
+    git-url	: https://github.com/mohammedzee1000/CentOS-Dockerfiles
+    git-path	: Django/centos7/
+    git-branch	: cccpyaml-test
+    notify-email: mohammed.zee1000@gmail.com
+    
+  - id		: default
+    app-id	: centos
+    job-id	: c6-earthquake
+    git-url	: https://github.com/mohammedzee1000/CentOS-Dockerfiles
+    git-path	: earthquake/centos6/
+    git-branch	: cccpyaml-test
+    notify-email: mohammed.zee1000@gmail.com
+    
+  - id		: default
+    app-id	: centos
+    job-id	: c7-earthquake
+    git-url	: https://github.com/mohammedzee1000/CentOS-Dockerfiles
+    git-path	: earthquake/centos7/
+    git-branch	: cccpyaml-test
+    notify-email: mohammed.zee1000@gmail.com
+    
+  - id		: default
+    app-id	: centos
+    job-id	: c7-etherpad
+    git-url	: https://github.com/mohammedzee1000/CentOS-Dockerfiles
+    git-path	: etherpad/centos7/
+    git-branch	: cccpyaml-test
+    notify-email: mohammed.zee1000@gmail.com
+    
+  - id		: default
+    app-id	: centos
+    job-id	: c6-firefox
+    git-url	: https://github.com/mohammedzee1000/CentOS-Dockerfiles
+    git-path	: firefox/centos6/
+    git-branch	: cccpyaml-test
+    notify-email: mohammed.zee1000@gmail.com
+    
+  - id		: default
+    app-id	: centos
+    job-id	: c7-firefox
+    git-url	: https://github.com/mohammedzee1000/CentOS-Dockerfiles
+    git-path	: firefox/centos7/
+    git-branch	: cccpyaml-test
+    notify-email: mohammed.zee1000@gmail.com
+    
+  - id		: default
+    app-id	: centos
+    job-id	: c7-freeipa
+    git-url	: https://github.com/mohammedzee1000/CentOS-Dockerfiles
+    git-path	: freeipa/centos7/
+    git-branch	: cccpyaml-test
+    notify-email: mohammed.zee1000@gmail.com
+    
+  - id		: default
+    app-id	: centos
+    job-id	: c6-httpd
+    git-url	: https://github.com/mohammedzee1000/CentOS-Dockerfiles
+    git-path	: httpd/centos6/
+    git-branch	: cccpyaml-test
+    notify-email: mohammed.zee1000@gmail.com
+    
+  - id		: default
+    app-id	: centos
+    job-id	: c7-httpd
+    git-url	: https://github.com/mohammedzee1000/CentOS-Dockerfiles
+    git-path	: httpd/centos7/
+    git-branch	: cccpyaml-test
+    notify-email: mohammed.zee1000@gmail.com
+    
+  - id		: default
+    app-id	: centos
+    job-id	: c6-lighttpd
+    git-url	: https://github.com/mohammedzee1000/CentOS-Dockerfiles
+    git-path	: lighttpd/centos6/
+    git-branch	: cccpyaml-test
+    notify-email: mohammed.zee1000@gmail.com
+    
+  - id		: default
+    app-id	: centos
+    job-id	: c7-lighttpd
+    git-url	: https://github.com/mohammedzee1000/CentOS-Dockerfiles
+    git-path	: lighttpd/centos7/
+    git-branch	: cccpyaml-test
+    notify-email: mohammed.zee1000@gmail.com
+    
+  - id		: default
+    app-id	: centos
+    job-id	: c7-mariadb
+    git-url	: https://github.com/mohammedzee1000/CentOS-Dockerfiles
+    git-path	: mariadb/centos7/
+    git-branch	: cccpyaml-test
+    notify-email: mohammed.zee1000@gmail.com
+    
+  - id		: default
+    app-id	: centos
+    job-id	: c6-memcached
+    git-url	: https://github.com/mohammedzee1000/CentOS-Dockerfiles
+    git-path	: memcached/centos6/
+    git-branch	: cccpyaml-test
+    notify-email: mohammed.zee1000@gmail.com
+    
+  - id		: default
+    app-id	: centos
+    job-id	: c7-memcached
+    git-url	: https://github.com/mohammedzee1000/CentOS-Dockerfiles
+    git-path	: memcached/centos7/
+    git-branch	: cccpyaml-test
+    notify-email: mohammed.zee1000@gmail.com
+    
+  - id		: default
+    app-id	: centos
+    job-id	: c6-mongodb
+    git-url	: https://github.com/mohammedzee1000/CentOS-Dockerfiles
+    git-path	: mongodb/centos6/
+    git-branch	: cccpyaml-test
+    notify-email: mohammed.zee1000@gmail.com
+    
+  - id		: default
+    app-id	: centos
+    job-id	: c7-mongodb
+    git-url	: https://github.com/mohammedzee1000/CentOS-Dockerfiles
+    git-path	: mongodb/centos7/
+    git-branch	: cccpyaml-test
+    notify-email: mohammed.zee1000@gmail.com
+    
+  - id		: default
+    app-id	: centos
+    job-id	: c6-mysql
+    git-url	: https://github.com/mohammedzee1000/CentOS-Dockerfiles
+    git-path	: mysql/centos6/
+    git-branch	: cccpyaml-test
+    notify-email: mohammed.zee1000@gmail.com
+    
+  - id		: default
+    app-id	: centos
+    job-id	: c6-mysql55
+    git-url	: https://github.com/mohammedzee1000/CentOS-Dockerfiles
+    git-path	: mysql55/centos6/
+    git-branch	: cccpyaml-test
+    notify-email: mohammed.zee1000@gmail.com
+    
+  - id		: default
+    app-id	: centos
+    job-id	: c6-nginx
+    git-url	: https://github.com/mohammedzee1000/CentOS-Dockerfiles
+    git-path	: nginx/centos6/
+    git-branch	: cccpyaml-test
+    notify-email: mohammed.zee1000@gmail.com
+    
+  - id		: default
+    app-id	: centos
+    job-id	: c7-nginx
+    git-url	: https://github.com/mohammedzee1000/CentOS-Dockerfiles
+    git-path	: nginx/centos7/
+    git-branch	: cccpyaml-test
+    notify-email: mohammed.zee1000@gmail.com
+    
+  - id		: default
+    app-id	: centos
+    job-id	: c6-nodejs
+    git-url	: https://github.com/mohammedzee1000/CentOS-Dockerfiles
+    git-path	: nodejs/centos6/
+    git-branch	: cccpyaml-test
+    notify-email: mohammed.zee1000@gmail.com
+    
+  - id		: default
+    app-id	: centos
+    job-id	: c6-owncloud
+    git-url	: https://github.com/mohammedzee1000/CentOS-Dockerfiles
+    git-path	: owncloud/centos6/
+    git-branch	: cccpyaml-test
+    notify-email: mohammed.zee1000@gmail.com
+    
+  - id		: default
+    app-id	: centos
+    job-id	: c7-owncloud
+    git-url	: https://github.com/mohammedzee1000/CentOS-Dockerfiles
+    git-path	: owncloud/centos7/
+    git-branch	: cccpyaml-test
+    notify-email: mohammed.zee1000@gmail.com
+    
+  - id		: default
+    app-id	: centos
+    job-id	: c6-postgres
+    git-url	: https://github.com/mohammedzee1000/CentOS-Dockerfiles
+    git-path	: postgres/centos6/
+    git-branch	: cccpyaml-test
+    notify-email: mohammed.zee1000@gmail.com
+    
+  - id		: default
+    app-id	: centos
+    job-id	: c7-postgres
+    git-url	: https://github.com/mohammedzee1000/CentOS-Dockerfiles
+    git-path	: postgres/centos7/
+    git-branch	: cccpyaml-test
+    notify-email: mohammed.zee1000@gmail.com
+    
+  - id		: default
+    app-id	: centos
+    job-id	: c6-python
+    git-url	: https://github.com/mohammedzee1000/CentOS-Dockerfiles
+    git-path	: python/centos6/
+    git-branch	: cccpyaml-test
+    notify-email: mohammed.zee1000@gmail.com
+    
+  - id		: default
+    app-id	: centos
+    job-id	: c7-python
+    git-url	: https://github.com/mohammedzee1000/CentOS-Dockerfiles
+    git-path	: python/centos7/
+    git-branch	: cccpyaml-test
+    notify-email: mohammed.zee1000@gmail.com
+    
+  - id		: default
+    app-id	: centos
+    job-id	: c6-qpid
+    git-url	: https://github.com/mohammedzee1000/CentOS-Dockerfiles
+    git-path	: qpid/centos6/
+    git-branch	: cccpyaml-test
+    notify-email: mohammed.zee1000@gmail.com
+    
+  - id		: default
+    app-id	: centos
+    job-id	: c7-qpid
+    git-url	: https://github.com/mohammedzee1000/CentOS-Dockerfiles
+    git-path	: qpid/centos7/
+    git-branch	: cccpyaml-test
+    notify-email: mohammed.zee1000@gmail.com
+    
+  - id		: default
+    app-id	: centos
+    job-id	: c6-rabbitmq
+    git-url	: https://github.com/mohammedzee1000/CentOS-Dockerfiles
+    git-path	: rabbitmq/centos6/
+    git-branch	: cccpyaml-test
+    notify-email: mohammed.zee1000@gmail.com
+    
+  - id		: default
+    app-id	: centos
+    job-id	: c7-rabbitmq
+    git-url	: https://github.com/mohammedzee1000/CentOS-Dockerfiles
+    git-path	: rabbitmq/centos7/
+    git-branch	: cccpyaml-test
+    notify-email: mohammed.zee1000@gmail.com
+    
+  - id		: default
+    app-id	: centos
+    job-id	: c6-redis
+    git-url	: https://github.com/mohammedzee1000/CentOS-Dockerfiles
+    git-path	: redis/centos6/
+    git-branch	: cccpyaml-test
+    notify-email: mohammed.zee1000@gmail.com
+    
+  - id		: default
+    app-id	: centos
+    job-id	: c7-redis
+    git-url	: https://github.com/mohammedzee1000/CentOS-Dockerfiles
+    git-path	: redis/centos7/
+    git-branch	: cccpyaml-test
+    notify-email: mohammed.zee1000@gmail.com
+    
+  - id		: default
+    app-id	: centos
+    job-id	: c6-registry
+    git-url	: https://github.com/mohammedzee1000/CentOS-Dockerfiles
+    git-path	: registry/centos6/
+    git-branch	: cccpyaml-test
+    notify-email: mohammed.zee1000@gmail.com
+    
+  - id		: default
+    app-id	: centos
+    job-id	: c7-registry
+    git-url	: https://github.com/mohammedzee1000/CentOS-Dockerfiles
+    git-path	: registry/centos7/
+    git-branch	: cccpyaml-test
+    notify-email: mohammed.zee1000@gmail.com
+    
+  - id		: default
+    app-id	: centos
+    job-id	: c7-registry-v2
+    git-url	: https://github.com/mohammedzee1000/CentOS-Dockerfiles
+    git-path	: registry-v2/centos7/
+    git-branch	: cccpyaml-test
+    notify-email: mohammed.zee1000@gmail.com
+    
+  - id		: default
+    app-id	: centos
+    job-id	: c6-ssh
+    git-url	: https://github.com/mohammedzee1000/CentOS-Dockerfiles
+    git-path	: ssh/centos6/
+    git-branch	: cccpyaml-test
+    notify-email: mohammed.zee1000@gmail.com
+    
+  - id		: default
+    app-id	: centos
+    job-id	: c7-ssh
+    git-url	: https://github.com/mohammedzee1000/CentOS-Dockerfiles
+    git-path	: ssh/centos7/
+    git-branch	: cccpyaml-test
+    notify-email: mohammed.zee1000@gmail.com
+    
+  - id		: default
+    app-id	: centos
+    job-id	: c7-tools
+    git-url	: https://github.com/mohammedzee1000/CentOS-Dockerfiles
+    git-path	: tools/centos7/
+    git-branch	: cccpyaml-test
+    notify-email: mohammed.zee1000@gmail.com
+    
+  - id		: default
+    app-id	: centos
+    job-id	: c7-wildfly
+    git-url	: https://github.com/mohammedzee1000/CentOS-Dockerfiles
+    git-path	: wildfly/centos7/
+    git-branch	: cccpyaml-test
+    notify-email: mohammed.zee1000@gmail.com
+    
+  - id		: default
+    app-id	: centos
+    job-id	: c6-wordpress
+    git-url	: https://github.com/mohammedzee1000/CentOS-Dockerfiles
+    git-path	: wordpress/centos6/
+    git-branch	: cccpyaml-test
+    notify-email: mohammed.zee1000@gmail.com
+    
+  - id		: default
+    app-id	: centos
+    job-id	: c7-wordpress
+    git-url	: https://github.com/mohammedzee1000/CentOS-Dockerfiles
+    git-path	: wordpress/centos7/
+    git-branch	: cccpyaml-test
+    notify-email: mohammed.zee1000@gmail.com
+    

--- a/index.yml
+++ b/index.yml
@@ -64,13 +64,13 @@ Projects:
     git-branch: master
     notify-email: cgoern@gmail.com
 
-#CentOS Dockerfiles Testrun
+#Centos Dockerfiles test
   - id		: default
     app-id	: centos
     job-id	: c6-bind
     git-url	: https://github.com/mohammedzee1000/CentOS-Dockerfiles
     git-path	: bind/centos6/
-    git-branch	: cccpyaml-test
+    git-branch	: master
     notify-email: mohammed.zee1000@gmail.com
     
   - id		: default
@@ -78,7 +78,7 @@ Projects:
     job-id	: c7-bind
     git-url	: https://github.com/mohammedzee1000/CentOS-Dockerfiles
     git-path	: bind/centos7/
-    git-branch	: cccpyaml-test
+    git-branch	: master
     notify-email: mohammed.zee1000@gmail.com
     
   - id		: default
@@ -86,7 +86,7 @@ Projects:
     job-id	: c6-couchdb
     git-url	: https://github.com/mohammedzee1000/CentOS-Dockerfiles
     git-path	: couchdb/centos6/
-    git-branch	: cccpyaml-test
+    git-branch	: master
     notify-email: mohammed.zee1000@gmail.com
     
   - id		: default
@@ -94,7 +94,7 @@ Projects:
     job-id	: c7-couchdb
     git-url	: https://github.com/mohammedzee1000/CentOS-Dockerfiles
     git-path	: couchdb/centos7/
-    git-branch	: cccpyaml-test
+    git-branch	: master
     notify-email: mohammed.zee1000@gmail.com
     
   - id		: default
@@ -102,7 +102,7 @@ Projects:
     job-id	: c6-Django
     git-url	: https://github.com/mohammedzee1000/CentOS-Dockerfiles
     git-path	: Django/centos6/
-    git-branch	: cccpyaml-test
+    git-branch	: master
     notify-email: mohammed.zee1000@gmail.com
     
   - id		: default
@@ -110,7 +110,7 @@ Projects:
     job-id	: c7-Django
     git-url	: https://github.com/mohammedzee1000/CentOS-Dockerfiles
     git-path	: Django/centos7/
-    git-branch	: cccpyaml-test
+    git-branch	: master
     notify-email: mohammed.zee1000@gmail.com
     
   - id		: default
@@ -118,7 +118,7 @@ Projects:
     job-id	: c6-earthquake
     git-url	: https://github.com/mohammedzee1000/CentOS-Dockerfiles
     git-path	: earthquake/centos6/
-    git-branch	: cccpyaml-test
+    git-branch	: master
     notify-email: mohammed.zee1000@gmail.com
     
   - id		: default
@@ -126,7 +126,7 @@ Projects:
     job-id	: c7-earthquake
     git-url	: https://github.com/mohammedzee1000/CentOS-Dockerfiles
     git-path	: earthquake/centos7/
-    git-branch	: cccpyaml-test
+    git-branch	: master
     notify-email: mohammed.zee1000@gmail.com
     
   - id		: default
@@ -134,7 +134,7 @@ Projects:
     job-id	: c7-etherpad
     git-url	: https://github.com/mohammedzee1000/CentOS-Dockerfiles
     git-path	: etherpad/centos7/
-    git-branch	: cccpyaml-test
+    git-branch	: master
     notify-email: mohammed.zee1000@gmail.com
     
   - id		: default
@@ -142,7 +142,7 @@ Projects:
     job-id	: c6-firefox
     git-url	: https://github.com/mohammedzee1000/CentOS-Dockerfiles
     git-path	: firefox/centos6/
-    git-branch	: cccpyaml-test
+    git-branch	: master
     notify-email: mohammed.zee1000@gmail.com
     
   - id		: default
@@ -150,7 +150,7 @@ Projects:
     job-id	: c7-firefox
     git-url	: https://github.com/mohammedzee1000/CentOS-Dockerfiles
     git-path	: firefox/centos7/
-    git-branch	: cccpyaml-test
+    git-branch	: master
     notify-email: mohammed.zee1000@gmail.com
     
   - id		: default
@@ -158,7 +158,7 @@ Projects:
     job-id	: c7-freeipa
     git-url	: https://github.com/mohammedzee1000/CentOS-Dockerfiles
     git-path	: freeipa/centos7/
-    git-branch	: cccpyaml-test
+    git-branch	: master
     notify-email: mohammed.zee1000@gmail.com
     
   - id		: default
@@ -166,7 +166,7 @@ Projects:
     job-id	: c6-httpd
     git-url	: https://github.com/mohammedzee1000/CentOS-Dockerfiles
     git-path	: httpd/centos6/
-    git-branch	: cccpyaml-test
+    git-branch	: master
     notify-email: mohammed.zee1000@gmail.com
     
   - id		: default
@@ -174,7 +174,7 @@ Projects:
     job-id	: c7-httpd
     git-url	: https://github.com/mohammedzee1000/CentOS-Dockerfiles
     git-path	: httpd/centos7/
-    git-branch	: cccpyaml-test
+    git-branch	: master
     notify-email: mohammed.zee1000@gmail.com
     
   - id		: default
@@ -182,7 +182,7 @@ Projects:
     job-id	: c6-lighttpd
     git-url	: https://github.com/mohammedzee1000/CentOS-Dockerfiles
     git-path	: lighttpd/centos6/
-    git-branch	: cccpyaml-test
+    git-branch	: master
     notify-email: mohammed.zee1000@gmail.com
     
   - id		: default
@@ -190,7 +190,7 @@ Projects:
     job-id	: c7-lighttpd
     git-url	: https://github.com/mohammedzee1000/CentOS-Dockerfiles
     git-path	: lighttpd/centos7/
-    git-branch	: cccpyaml-test
+    git-branch	: master
     notify-email: mohammed.zee1000@gmail.com
     
   - id		: default
@@ -198,7 +198,7 @@ Projects:
     job-id	: c7-mariadb
     git-url	: https://github.com/mohammedzee1000/CentOS-Dockerfiles
     git-path	: mariadb/centos7/
-    git-branch	: cccpyaml-test
+    git-branch	: master
     notify-email: mohammed.zee1000@gmail.com
     
   - id		: default
@@ -206,7 +206,7 @@ Projects:
     job-id	: c6-memcached
     git-url	: https://github.com/mohammedzee1000/CentOS-Dockerfiles
     git-path	: memcached/centos6/
-    git-branch	: cccpyaml-test
+    git-branch	: master
     notify-email: mohammed.zee1000@gmail.com
     
   - id		: default
@@ -214,7 +214,7 @@ Projects:
     job-id	: c7-memcached
     git-url	: https://github.com/mohammedzee1000/CentOS-Dockerfiles
     git-path	: memcached/centos7/
-    git-branch	: cccpyaml-test
+    git-branch	: master
     notify-email: mohammed.zee1000@gmail.com
     
   - id		: default
@@ -222,7 +222,7 @@ Projects:
     job-id	: c6-mongodb
     git-url	: https://github.com/mohammedzee1000/CentOS-Dockerfiles
     git-path	: mongodb/centos6/
-    git-branch	: cccpyaml-test
+    git-branch	: master
     notify-email: mohammed.zee1000@gmail.com
     
   - id		: default
@@ -230,7 +230,7 @@ Projects:
     job-id	: c7-mongodb
     git-url	: https://github.com/mohammedzee1000/CentOS-Dockerfiles
     git-path	: mongodb/centos7/
-    git-branch	: cccpyaml-test
+    git-branch	: master
     notify-email: mohammed.zee1000@gmail.com
     
   - id		: default
@@ -238,7 +238,7 @@ Projects:
     job-id	: c6-mysql
     git-url	: https://github.com/mohammedzee1000/CentOS-Dockerfiles
     git-path	: mysql/centos6/
-    git-branch	: cccpyaml-test
+    git-branch	: master
     notify-email: mohammed.zee1000@gmail.com
     
   - id		: default
@@ -246,7 +246,7 @@ Projects:
     job-id	: c6-mysql55
     git-url	: https://github.com/mohammedzee1000/CentOS-Dockerfiles
     git-path	: mysql55/centos6/
-    git-branch	: cccpyaml-test
+    git-branch	: master
     notify-email: mohammed.zee1000@gmail.com
     
   - id		: default
@@ -254,7 +254,7 @@ Projects:
     job-id	: c6-nginx
     git-url	: https://github.com/mohammedzee1000/CentOS-Dockerfiles
     git-path	: nginx/centos6/
-    git-branch	: cccpyaml-test
+    git-branch	: master
     notify-email: mohammed.zee1000@gmail.com
     
   - id		: default
@@ -262,7 +262,7 @@ Projects:
     job-id	: c7-nginx
     git-url	: https://github.com/mohammedzee1000/CentOS-Dockerfiles
     git-path	: nginx/centos7/
-    git-branch	: cccpyaml-test
+    git-branch	: master
     notify-email: mohammed.zee1000@gmail.com
     
   - id		: default
@@ -270,7 +270,7 @@ Projects:
     job-id	: c6-nodejs
     git-url	: https://github.com/mohammedzee1000/CentOS-Dockerfiles
     git-path	: nodejs/centos6/
-    git-branch	: cccpyaml-test
+    git-branch	: master
     notify-email: mohammed.zee1000@gmail.com
     
   - id		: default
@@ -278,7 +278,7 @@ Projects:
     job-id	: c6-owncloud
     git-url	: https://github.com/mohammedzee1000/CentOS-Dockerfiles
     git-path	: owncloud/centos6/
-    git-branch	: cccpyaml-test
+    git-branch	: master
     notify-email: mohammed.zee1000@gmail.com
     
   - id		: default
@@ -286,7 +286,7 @@ Projects:
     job-id	: c7-owncloud
     git-url	: https://github.com/mohammedzee1000/CentOS-Dockerfiles
     git-path	: owncloud/centos7/
-    git-branch	: cccpyaml-test
+    git-branch	: master
     notify-email: mohammed.zee1000@gmail.com
     
   - id		: default
@@ -294,7 +294,7 @@ Projects:
     job-id	: c6-postgres
     git-url	: https://github.com/mohammedzee1000/CentOS-Dockerfiles
     git-path	: postgres/centos6/
-    git-branch	: cccpyaml-test
+    git-branch	: master
     notify-email: mohammed.zee1000@gmail.com
     
   - id		: default
@@ -302,7 +302,7 @@ Projects:
     job-id	: c7-postgres
     git-url	: https://github.com/mohammedzee1000/CentOS-Dockerfiles
     git-path	: postgres/centos7/
-    git-branch	: cccpyaml-test
+    git-branch	: master
     notify-email: mohammed.zee1000@gmail.com
     
   - id		: default
@@ -310,15 +310,15 @@ Projects:
     job-id	: c6-python
     git-url	: https://github.com/mohammedzee1000/CentOS-Dockerfiles
     git-path	: python/centos6/
-    git-branch	: cccpyaml-test
+    git-branch	: master
     notify-email: mohammed.zee1000@gmail.com
     
-  - id		: default
+  - id          : default      
     app-id	: centos
     job-id	: c7-python
     git-url	: https://github.com/mohammedzee1000/CentOS-Dockerfiles
     git-path	: python/centos7/
-    git-branch	: cccpyaml-test
+    git-branch	: master
     notify-email: mohammed.zee1000@gmail.com
     
   - id		: default
@@ -326,7 +326,7 @@ Projects:
     job-id	: c6-qpid
     git-url	: https://github.com/mohammedzee1000/CentOS-Dockerfiles
     git-path	: qpid/centos6/
-    git-branch	: cccpyaml-test
+    git-branch	: master
     notify-email: mohammed.zee1000@gmail.com
     
   - id		: default
@@ -334,7 +334,7 @@ Projects:
     job-id	: c7-qpid
     git-url	: https://github.com/mohammedzee1000/CentOS-Dockerfiles
     git-path	: qpid/centos7/
-    git-branch	: cccpyaml-test
+    git-branch	: master
     notify-email: mohammed.zee1000@gmail.com
     
   - id		: default
@@ -342,7 +342,7 @@ Projects:
     job-id	: c6-rabbitmq
     git-url	: https://github.com/mohammedzee1000/CentOS-Dockerfiles
     git-path	: rabbitmq/centos6/
-    git-branch	: cccpyaml-test
+    git-branch	: master
     notify-email: mohammed.zee1000@gmail.com
     
   - id		: default
@@ -350,7 +350,7 @@ Projects:
     job-id	: c7-rabbitmq
     git-url	: https://github.com/mohammedzee1000/CentOS-Dockerfiles
     git-path	: rabbitmq/centos7/
-    git-branch	: cccpyaml-test
+    git-branch	: master
     notify-email: mohammed.zee1000@gmail.com
     
   - id		: default
@@ -358,7 +358,7 @@ Projects:
     job-id	: c6-redis
     git-url	: https://github.com/mohammedzee1000/CentOS-Dockerfiles
     git-path	: redis/centos6/
-    git-branch	: cccpyaml-test
+    git-branch	: master
     notify-email: mohammed.zee1000@gmail.com
     
   - id		: default
@@ -366,7 +366,7 @@ Projects:
     job-id	: c7-redis
     git-url	: https://github.com/mohammedzee1000/CentOS-Dockerfiles
     git-path	: redis/centos7/
-    git-branch	: cccpyaml-test
+    git-branch	: master
     notify-email: mohammed.zee1000@gmail.com
     
   - id		: default
@@ -374,7 +374,7 @@ Projects:
     job-id	: c6-registry
     git-url	: https://github.com/mohammedzee1000/CentOS-Dockerfiles
     git-path	: registry/centos6/
-    git-branch	: cccpyaml-test
+    git-branch	: master
     notify-email: mohammed.zee1000@gmail.com
     
   - id		: default
@@ -382,7 +382,7 @@ Projects:
     job-id	: c7-registry
     git-url	: https://github.com/mohammedzee1000/CentOS-Dockerfiles
     git-path	: registry/centos7/
-    git-branch	: cccpyaml-test
+    git-branch	: master
     notify-email: mohammed.zee1000@gmail.com
     
   - id		: default
@@ -390,7 +390,7 @@ Projects:
     job-id	: c7-registry-v2
     git-url	: https://github.com/mohammedzee1000/CentOS-Dockerfiles
     git-path	: registry-v2/centos7/
-    git-branch	: cccpyaml-test
+    git-branch	: master
     notify-email: mohammed.zee1000@gmail.com
     
   - id		: default
@@ -398,7 +398,7 @@ Projects:
     job-id	: c6-ssh
     git-url	: https://github.com/mohammedzee1000/CentOS-Dockerfiles
     git-path	: ssh/centos6/
-    git-branch	: cccpyaml-test
+    git-branch	: master
     notify-email: mohammed.zee1000@gmail.com
     
   - id		: default
@@ -406,7 +406,7 @@ Projects:
     job-id	: c7-ssh
     git-url	: https://github.com/mohammedzee1000/CentOS-Dockerfiles
     git-path	: ssh/centos7/
-    git-branch	: cccpyaml-test
+    git-branch	: master
     notify-email: mohammed.zee1000@gmail.com
     
   - id		: default
@@ -414,7 +414,7 @@ Projects:
     job-id	: c7-tools
     git-url	: https://github.com/mohammedzee1000/CentOS-Dockerfiles
     git-path	: tools/centos7/
-    git-branch	: cccpyaml-test
+    git-branch	: master
     notify-email: mohammed.zee1000@gmail.com
     
   - id		: default
@@ -422,7 +422,7 @@ Projects:
     job-id	: c7-wildfly
     git-url	: https://github.com/mohammedzee1000/CentOS-Dockerfiles
     git-path	: wildfly/centos7/
-    git-branch	: cccpyaml-test
+    git-branch	: master
     notify-email: mohammed.zee1000@gmail.com
     
   - id		: default
@@ -430,7 +430,7 @@ Projects:
     job-id	: c6-wordpress
     git-url	: https://github.com/mohammedzee1000/CentOS-Dockerfiles
     git-path	: wordpress/centos6/
-    git-branch	: cccpyaml-test
+    git-branch	: master
     notify-email: mohammed.zee1000@gmail.com
     
   - id		: default
@@ -438,6 +438,6 @@ Projects:
     job-id	: c7-wordpress
     git-url	: https://github.com/mohammedzee1000/CentOS-Dockerfiles
     git-path	: wordpress/centos7/
-    git-branch	: cccpyaml-test
+    git-branch	: master
     notify-email: mohammed.zee1000@gmail.com
     

--- a/index.yml.back
+++ b/index.yml.back
@@ -1,0 +1,65 @@
+# This is the main index.
+
+Projects:
+  - id          : default
+    app-id      : 
+    job-id      : 
+    git-url     : 
+    git-path    : 
+    git-branch  :
+    notify-email: 
+
+# Add your job below this line, you can use the 'default' project
+# from the top of this file as a template. All values are required.
+
+#bamachrn
+  - id          : default
+    app-id      : bamachrn
+    job-id      : python
+    git-url     : https://github.com/bamachrn/cccp-python
+    git-path    : /
+    git-branch  : master
+    notify-email: bamachrn@gmail.com
+
+# kbsingh
+  - id          : default
+    app-id      : kbsingh
+    job-id      : c7-httpd
+    git-url     : https://github.com/kbsingh/CentOS-Dockerfiles
+    git-path    : httpd/centos7
+    git-branch  : master
+    notify-email: cccp.inb@karan.org
+
+  - id          : default
+    app-id      : kbsingh
+    job-id      : c7-tools
+    git-url     : https://github.com/kbsingh/CentOS-Dockerfiles
+    git-path    : tools/
+    git-branch  : master
+    notify-email: cccp.inb@karan.org
+
+# vpavlin
+  - id          : default
+    app-id      : vpavlin
+    job-id      : ahoj_svete
+    git-url     : https://github.com/vpavlin/ahoj_svete
+    git-path    : /
+    git-branch  : master
+    notify-email: vaclav.pavlin@gmail.com
+
+  - id          : default
+    app-id      : pulp
+    job-id      : admin-client
+    git-url     : https://github.com/vpavlin/pulp_packaging
+    git-path    : dockerfiles/centos/admin-client
+    git-branch  : master
+    notify-email: vaclav.pavlin@gmail.com
+
+#cgoern
+  - id: goern
+    job-id: goern-skydns-atomicapp-1
+    app-id: skydns-atomicapp
+    git-url: https://github.com/goern/skydns-atomicapp
+    git-path: /
+    git-branch: master
+    notify-email: cgoern@gmail.com


### PR DESCRIPTION
For the purpose of testing the functionality of the Centos Community
Container Pipeline, I have created script to walk thorugh the Centos-
Dockerfiles and generate index entries for the same. This script MUST
be run after cloning both repositores into a system as paths are expected.

Fixes Issue #16 
